### PR TITLE
Add support for deploying with the 'deploy-pr' label,

### DIFF
--- a/buildbot/deploy
+++ b/buildbot/deploy
@@ -20,6 +20,7 @@ source <(grep personal_access_token ${SCRIPTROOT}/credentials.ini)
 # These IDs are no secret and can be retrieved by an API call to https://api.github.com/orgs/reactos/teams
 developer_group_id=2505522          # "ReactOS Developer Team"
 trusted_group_id=3404185            # "Trusted Web-Playground Users"
+deploy_label=deploy-pr
 
 
 subdomain=`get_subdomain ${branch}`
@@ -38,13 +39,16 @@ elif [[ "${branch}" =~ ^refs/pull/([0-9]+)/ ]]; then
 
 	# First get the GitHub username of the Pull Request author.
 	pr_number=${BASH_REMATCH[1]}
-	username=`get_pr_username ${pr_number}`
+	pr_data=`get_pr_data ${pr_number}`
+	username=`get_pr_username "${pr_data}"`
+	labels=`get_pr_labels "${pr_data}"`
 
 	# Check if this user is either part of the developer team or the additional group of trusted people.
-	if ! { check_team_membership ${username} ${developer_group_id} || check_team_membership ${username} ${trusted_group_id}; }; then
+	if ! { check_team_membership ${username} ${developer_group_id} || check_team_membership ${username} ${trusted_group_id} || check_pr_label "${labels}" ${deploy_label}; }; then
 		echo "This script would usually deploy the build result of your Pull Request to ${target_url}"
 		echo "However, to prevent abuse, your GitHub account first needs to be added to the trusted user list."
-		echo "Ask someone from the developer team if you need this deployment feature and want to be added to the trusted user list."
+		echo "If you want to make use of this feature, ask someone from the developer team to add the 'deploy-pr' label to this PR,"
+		echo "or to add you to the trusted user list."
 		exit 0
 	fi
 

--- a/buildbot/functions
+++ b/buildbot/functions
@@ -14,11 +14,34 @@ check_team_membership() {
 	fi
 }
 
+check_pr_label() {
+	local labels="$1"
+	local search_label="$2"
+
+	if echo "$labels" | grep -qFx "$search_label"; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 # Get the GitHub username for the person that submitted a web-content Pull Request
 get_pr_username() {
+	local pr_data="$1"
+
+	echo "$pr_data" | jq -r '.user.login'
+}
+
+get_pr_labels() {
+	local pr_data="$1"
+
+	echo "$pr_data" | jq -r '.labels[].name'
+}
+
+get_pr_data() {
 	local pr_number=$1
 
-	curl -s https://api.github.com/repos/reactos/web-content/pulls/${pr_number} | jq -r '.user.login'
+	curl -s https://api.github.com/repos/reactos/web-content/pulls/${pr_number}
 }
 
 # Outputs the *.web-content.reactos.org subdomain for deployment, or "invalid" if this branch is not deployed.


### PR DESCRIPTION
instead of adding all users to the trusted list.

TODO:

- [ ] The script is tested locally against https://github.com/reactos/web-content/pull/5 (sorry victor) in wsl, so it might make sense to also test it on the buildbot machine
- [ ] Check the code
- [ ] Trigger the buildbot on labels changed event: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request